### PR TITLE
fix: mm local storage dependency

### DIFF
--- a/app/components/connect-button.tsx
+++ b/app/components/connect-button.tsx
@@ -87,7 +87,9 @@ export function ConnectButton() {
                   text-zinc-900 dark:text-white border border-zinc-200 dark:border-zinc-700`}
               >
                 <span className="flex items-center gap-2">
-                  {connector.name}
+                  {connector.name === "Injected"
+                    ? "Browser Wallet"
+                    : connector.name}
                 </span>
               </button>
             ))}

--- a/app/lib/wagmi.ts
+++ b/app/lib/wagmi.ts
@@ -1,5 +1,5 @@
 import { http, createConfig, createStorage, cookieStorage } from "wagmi";
-import { walletConnect, metaMask } from "wagmi/connectors";
+import { walletConnect, injected } from "wagmi/connectors";
 
 export const projectId = "44a3ab7bcd31b7ffa35330deed568d13";
 
@@ -30,6 +30,6 @@ export const config = createConfig({
   transports: {
     [bittensorTestnet.id]: http(),
   },
-  connectors: [walletConnect({ projectId }), metaMask()],
+  connectors: [walletConnect({ projectId }), injected()],
   ssr: true,
 });


### PR DESCRIPTION
The metamask connector was using local storage, killing server components. Instead I opted to rely only on the injected provider which is generally quite flexible and common